### PR TITLE
sunfish: Build LiveDisplay 2.0 HAL

### DIFF
--- a/BoardConfig-common.mk
+++ b/BoardConfig-common.mk
@@ -214,6 +214,10 @@ TARGET_USES_DISPLAY_RENDER_INTENTS := true
 TARGET_USES_COLOR_METADATA := true
 TARGET_USES_DRM_PP := true
 
+# SELinux
+BOARD_SEPOLICY_DIRS += device/google/sunfish/sepolicy-descendant/dynamic
+BOARD_SEPOLICY_DIRS += device/google/sunfish/sepolicy-descendant/vendor
+
 # Vendor Interface Manifest
 DEVICE_MANIFEST_FILE := device/google/sunfish/manifest.xml
 DEVICE_MATRIX_FILE := device/google/sunfish/compatibility_matrix.xml

--- a/device_framework_matrix.xml
+++ b/device_framework_matrix.xml
@@ -15,6 +15,19 @@
             <instance>com.qualcomm.qti.uceservice</instance>
         </interface>
     </hal>
+    <hal format="hidl" optional="true">
+        <name>vendor.lineage.livedisplay</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IPictureAdjustment</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IAdaptiveBacklight</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
     <hal format="hidl">
         <name>vendor.qti.data.factory</name>
         <transport>hwbinder</transport>

--- a/manifest.xml
+++ b/manifest.xml
@@ -281,6 +281,16 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <fqname>@1.1::IGnss/default</fqname>
         <fqname>@2.0::IGnss/default</fqname>
     </hal>
+    <!-- livedisplay -->
+    <hal format="hidl">
+        <name>vendor.lineage.livedisplay</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IPictureAdjustment</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
     <!-- qcrilhook -->
     <hal format="hidl">
         <name>vendor.qti.hardware.radio.qcrilhook</name>

--- a/sepolicy-descendant/dynamic/hal_lineage_livedisplay_qti.te
+++ b/sepolicy-descendant/dynamic/hal_lineage_livedisplay_qti.te
@@ -1,0 +1,10 @@
+# Do not use add_service() as hal_graphics_composer_default may be the provider as well
+allow hal_lineage_livedisplay_qti qdisplay_service:service_manager find;
+
+binder_call(hal_lineage_livedisplay_qti, hal_graphics_composer_default)
+
+# Allow LiveDisplay to access vendor display property
+get_prop(hal_lineage_livedisplay_qti, vendor_display_prop)
+
+allow hal_lineage_livedisplay_qti pps_socket:sock_file rw_file_perms;
+allow hal_lineage_livedisplay_qti hal_graphics_composer_default:unix_stream_socket { connectto };

--- a/sepolicy-descendant/vendor/file_contexts
+++ b/sepolicy-descendant/vendor/file_contexts
@@ -1,0 +1,2 @@
+# LiveDisplay HAL
+/(vendor|system/vendor)/bin/hw/vendor\.lineage\.livedisplay@2\.0-service-sdm      u:object_r:hal_lineage_livedisplay_qti_exec:s0

--- a/sepolicy-descendant/vendor/hal_lineage_livedisplay.te
+++ b/sepolicy-descendant/vendor/hal_lineage_livedisplay.te
@@ -1,0 +1,12 @@
+type hal_lineage_livedisplay_qti, domain;
+hal_server_domain(hal_lineage_livedisplay_qti, hal_lineage_livedisplay)
+
+type hal_lineage_livedisplay_qti_exec, exec_type, vendor_file_type, file_type;
+init_daemon_domain(hal_lineage_livedisplay_qti)
+
+# Allow LiveDisplay HAL's default implementation to use vendor-binder service
+vndbinder_use(hal_lineage_livedisplay_qti)
+
+# Allow LiveDisplay to store files under /data/vendor/display and access them
+allow hal_lineage_livedisplay_qti display_vendor_data_file:dir rw_dir_perms;
+allow hal_lineage_livedisplay_qti display_vendor_data_file:file create_file_perms;


### PR DESCRIPTION
* Lets use the common solution, and change our supported
  interfaces while we're at it:
 * Our panel (by default) uses AOSP color profiles.
 * Our panel does get along with Color Calibration &
   Reading Mode, which are done SDK side, and require
   no HIDL manifest entries.
 * Our panel does get along with Picture Adjustment
   features, so leave IPictureAdjustment in place.
 * Our panel does get along with Adaptive Backlight
   features, so leave IAdaptiveBacklight in place.
 * AOSP declares `ro.vendor.display.foss` but we don't
   have support for IAdaptiveBacklight, so don't declare.

Change-Id: Ia96134e0a4bb06269b48671a87991d5e7a53d9ed